### PR TITLE
feat: add capability to customise TypeRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 UI Automation framework / solution implemented in Java to support web browser as well as mobile browser / App automation. This includes
 
 * abstraction for PageObject
-* ContextLoader for Spring context initialization
+* ContextLoader for Spring context initialisation
 * TestNg test runner that kicks off cucumber
 * Spring Boot application configuration
 * Webdriver properties, test data properties
@@ -156,9 +156,21 @@ To use this automation framework in your test suite:
 	mvn test -Dcucumber.options=@target/rerun.txt -Dspring.profiles.active=chrome -DthreadCount=4
 	```
 
+## Configuring the TypeRegistry
+
+Cucumber 3+ provides `TypeRegistryConfigurer` to configure custom parameter types and data table types. The framework already defines one to setup a default DataTable Transformer using Jackson library.
+To extend it, please use ServiceLoader mechanism:
+
+* Create an implementation of `DataTableTypeProvider` or `ParameterTypeProvider`
+* In your test suite, add file(s) with the implementations referenced:
+    * `META-INF/services/com.github.kripaliz.automation.cucumber.DataTableTypeProvider`
+    * `META-INF/services/com.github.kripaliz.automation.cucumber.ParameterTypeProvider`
+
+Here's some more info on ServiceLoader; https://www.baeldung.com/java-spi
+
 ## Setting up eclipse for developing
 
 * Download [eclipse](https://www.eclipse.org/downloads/)
 * Follow instructions [here](https://projectlombok.org/setup/eclipse) for lombok setup
-* Install eclipse plugins from the [eclipse marketplace](https://marketplace.eclipse.org/content/welcome-eclipse-marketplace) or using their [update site](https://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Ftasks%2Ftasks-127.htm) - [TestNG](https://dl.bintray.com/testng-team/testng-eclipse-release/6.14.3/), [YEdit](http://dadacoalition.org/yedit/), [Cucumber](https://marketplace.eclipse.org/content/cucumber-eclipse-plugin)
+* Install eclipse plugins from the [eclipse marketplace](https://marketplace.eclipse.org/content/welcome-eclipse-marketplace) or using their [update site](https://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Ftasks%2Ftasks-127.htm) - [TestNG](https://dl.bintray.com/testng-team/testng-eclipse-release/6.14.3/), [YEdit](http://dadacoalition.org/yedit/), [Cucumber](https://cucumber.github.io/cucumber-eclipse-update-site-snapshot)
 * Follow instructions in the answer [here](https://stackoverflow.com/questions/1886185/eclipse-and-windows-newlines) to use Unix style line endings for new files

--- a/src/main/java/com/github/kripaliz/automation/cucumber/DataTableTypeProvider.java
+++ b/src/main/java/com/github/kripaliz/automation/cucumber/DataTableTypeProvider.java
@@ -1,0 +1,25 @@
+/**
+ *
+ */
+package com.github.kripaliz.automation.cucumber;
+
+import java.util.ServiceLoader;
+
+import io.cucumber.core.api.TypeRegistry;
+import io.cucumber.datatable.DataTableType;
+
+/**
+ * Implement this interface to add custom {@link DataTableType}s.
+ * Implementations are added to {@link TypeRegistry} using {@link ServiceLoader}
+ *
+ * @author kkurian
+ */
+public interface DataTableTypeProvider {
+
+	/**
+	 * Create a {@link DataTableType} to be added to cucumber4 {@link TypeRegistry}
+	 *
+	 * @return {@link DataTableType}
+	 */
+	DataTableType create();
+}

--- a/src/main/java/com/github/kripaliz/automation/cucumber/ParameterTypeProvider.java
+++ b/src/main/java/com/github/kripaliz/automation/cucumber/ParameterTypeProvider.java
@@ -1,0 +1,23 @@
+package com.github.kripaliz.automation.cucumber;
+
+import java.util.ServiceLoader;
+
+import io.cucumber.core.api.TypeRegistry;
+import io.cucumber.cucumberexpressions.ParameterType;
+
+/**
+ * Implement this interface to add custom {@link ParameterType}s.
+ * Implementations are added to {@link TypeRegistry} using {@link ServiceLoader}
+ *
+ * @author kkurian
+ *
+ */
+public interface ParameterTypeProvider<T> {
+
+	/**
+	 * Create a {@link ParameterType} to be added to cucumber4 {@link TypeRegistry}
+	 *
+	 * @return {@link ParameterType}
+	 */
+	ParameterType<T> create();
+}

--- a/src/main/java/com/github/kripaliz/automation/cucumber/glue/TypeRegistryConfiguration.java
+++ b/src/main/java/com/github/kripaliz/automation/cucumber/glue/TypeRegistryConfiguration.java
@@ -2,8 +2,11 @@ package com.github.kripaliz.automation.cucumber.glue;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.kripaliz.automation.cucumber.DataTableTypeProvider;
+import com.github.kripaliz.automation.cucumber.ParameterTypeProvider;
 
 import io.cucumber.core.api.TypeRegistry;
 import io.cucumber.core.api.TypeRegistryConfigurer;
@@ -13,7 +16,7 @@ import io.cucumber.datatable.TableEntryByTypeTransformer;
 /**
  * Default converter that will handle all types for which no converter has been
  * defined
- * 
+ *
  * @author kkurian
  * @see https://cucumber.io/blog/announcing-cucumber-jvm-4-0-0/
  */
@@ -28,6 +31,19 @@ public class TypeRegistryConfiguration implements TypeRegistryConfigurer {
 	public void configureTypeRegistry(final TypeRegistry typeRegistry) {
 		final JacksonTableTransformer jacksonTableTransformer = new JacksonTableTransformer();
 		typeRegistry.setDefaultDataTableEntryTransformer(jacksonTableTransformer);
+
+		final ServiceLoader<DataTableTypeProvider> dataTableTypeloader = ServiceLoader
+				.load(DataTableTypeProvider.class);
+		dataTableTypeloader.forEach(dataTableTypeProvider -> {
+			typeRegistry.defineDataTableType(dataTableTypeProvider.create());
+		});
+		@SuppressWarnings("rawtypes")
+		final ServiceLoader<ParameterTypeProvider> parameterTypeLoader = ServiceLoader
+				.load(ParameterTypeProvider.class);
+		parameterTypeLoader.forEach(parameterTypeProvider -> {
+			typeRegistry.defineParameterType(parameterTypeProvider.create());
+		});
+
 	}
 
 	private static final class JacksonTableTransformer


### PR DESCRIPTION
test suites can implement DataTableTypeProvider and/or
ParameterTypeProvider to add `DataTableType`s and/or `ParameterType`s to
`TypeRegistry`